### PR TITLE
Add Ell breakout type.

### DIFF
--- a/lib/src/bls/fp12.nr
+++ b/lib/src/bls/fp12.nr
@@ -1,5 +1,6 @@
 use crate::bls::fp2::Fp2;
 use crate::bls::fp6::Fp6;
+use crate::bls::pairing::Ell;
 
 /// Polynomial Extension Field Tower of Degree `12`.
 ///
@@ -167,6 +168,26 @@ impl Fp12 {
         let mut c1 = self.c1.add(self.c0);
         c1 = c1.mul_by_01(c0, o);
         c1 = c1.sub(aa).sub(bb);
+        let mut c0 = bb;
+        c0 = c0.mul_by_nonresidue();
+        c0 = c0.add(aa);
+
+        Fp12 { c0, c1 }
+    }
+
+    /// Sparse multiplication by an Ell instance.
+    ///
+    /// Ell is defined as a succinct representation of an Fp12 element with three non-zero
+    /// coefficients. See the `pairing` module for more on Ell.
+    pub fn sparse_mul(self, ell: Ell) -> Fp12 {
+        let aa = self.c0.mul_by_01(ell.c0_c0, ell.c1_c0);
+        let bb = self.c1.mul_by_1(ell.c1_c1);
+        let o = ell.c1_c0.add(ell.c1_c1);
+
+        let mut c1 = self.c1.add(self.c0);
+        c1 = c1.mul_by_01(ell.c0_c0, o);
+        c1 = c1.sub(aa).sub(bb);
+
         let mut c0 = bb;
         c0 = c0.mul_by_nonresidue();
         c0 = c0.add(aa);

--- a/lib/src/bls/fp2.nr
+++ b/lib/src/bls/fp2.nr
@@ -143,6 +143,11 @@ impl Fp2 {
         }
     }
 
+    /// Scales the element by an element of Fp.
+    pub fn scale(self, scalar: Fp) -> Self {
+        Self { c0: self.c0 * scalar, c1: self.c1 * scalar }
+    }
+
     /// Multiplies the element by the quadratic non-residue `u` in `Fp2`.
     ///
     /// This is used for optimized multiplication over `Fp2`.

--- a/lib/src/bls/mod.nr
+++ b/lib/src/bls/mod.nr
@@ -3,3 +3,4 @@ pub mod fp6;
 pub mod fp12;
 pub mod g1;
 pub mod g2;
+pub mod pairing;

--- a/lib/src/bls/pairing.nr
+++ b/lib/src/bls/pairing.nr
@@ -4,10 +4,57 @@ use crate::bls::g1::G1Affine;
 use crate::bls::g2::{G2Affine, G2Projective};
 use crate::helpers::__final_exponentiation;
 
+/// Encapsulates sparse non-zero coefficients in Fp12.
+///
+/// There are multiple operations over elements of Fp12 where the majority of coefficients are zero,
+/// which results in unnecessary operations.
+///
+/// We define a data structure representing a more succinct form of the following.
+///
+/// ```
+/// Fp12 {
+///     c0: Fp6 {
+///        c0: Fp2 { .. },
+///        c1: Fp2::zero(),
+///        c2: Fp2::zero(),
+///     },
+///     c1: Fp6 {
+///        c0: Fp2 { .. },
+///        c1: Fp2 { .. },
+///        c2: Fp2::zero(),
+///     },
+/// }
+/// ```
+///
+/// In particular, we define this for the point doubling/addition and line evaluation algorithms.
+///
+/// Reference Document: https://eprint.iacr.org/2010/354.pdf (Algorithm 26, 27).
+pub(crate) struct Ell {
+    pub(crate) c0_c0: Fp2,
+    pub(crate) c1_c0: Fp2,
+    pub(crate) c1_c1: Fp2,
+}
+
+impl Ell {
+    /// Constructs an Ell instance with coefficients in Fp2.
+    pub(crate) fn new(c0_c0: Fp2, c1_c0: Fp2, c1_c1: Fp2) -> Self {
+        Self { c0_c0, c1_c0, c1_c1 }
+    }
+
+    /// Scales the coefficients of an Ell instance by an affine point.
+    pub(crate) fn scale_by_affine(self, p: G1Affine) -> Self {
+        Self {
+            c0_c0: self.c0_c0,
+            c1_c0: self.c1_c0.scale(p.x),
+            c1_c1: self.c1_c1.scale(p.y),
+        }
+    }
+}
+
 /// Performs the doubling step of the Miller Algorithm and evaluates the line function.
 ///
 /// Reference Document: https://eprint.iacr.org/2010/354.pdf (Algorithm 26)
-pub(crate) fn doubling_step(r: G2Projective) -> (Fp2, Fp2, Fp2, G2Projective) {
+pub(crate) fn doubling_step(r: G2Projective) -> (Ell, G2Projective) {
     let mut tmp0 = r.x.square();
     let mut tmp1 = r.y.square();
     let mut tmp2 = tmp1.square();
@@ -34,13 +81,13 @@ pub(crate) fn doubling_step(r: G2Projective) -> (Fp2, Fp2, Fp2, G2Projective) {
     tmp0 = new_r_z.mul(zsquared);
     tmp0 = tmp0.add(tmp0);
 
-    (tmp0, tmp3, tmp6, G2Projective { x: new_r_x, y: new_r_y, z: new_r_z })
+    (Ell::new(tmp6, tmp3, tmp0), G2Projective { x: new_r_x, y: new_r_y, z: new_r_z })
 }
 
 /// Performs the addition step of the Miller Algorithm and evaluates the line function.
 ///
 /// Reference Document: https://eprint.iacr.org/2010/354.pdf (Algorithm 26)
-pub(crate) fn addition_step(r: G2Projective, q: G2Affine) -> (Fp2, Fp2, Fp2, G2Projective) {
+pub(crate) fn addition_step(r: G2Projective, q: G2Affine) -> (Ell, G2Projective) {
     let zsquared = r.z.square();
     let ysquared = q.y.square();
     let mut t0 = zsquared.mul(q.x);
@@ -73,24 +120,7 @@ pub(crate) fn addition_step(r: G2Projective, q: G2Affine) -> (Fp2, Fp2, Fp2, G2P
     let t10_double = new_r_z.add(new_r_z);
     let t6_neg = t6.neg();
     let t1_final = t6_neg.add(t6_neg);
-    (t10_double, t1_final, t9, G2Projective { x: new_r_x, y: new_r_y, z: new_r_z })
-}
-
-/// Performse sparse multiplication between `Fp12` and a triple of elements in `Fp2`.
-///
-/// The elements of `Fp2` represent non-zero coefficients in an element of `Fp12`. As algorithms
-/// 26 and 27 in the reference document below evaluate the line function internally, and as most
-/// of the evaluated coefficients are always zero, we represent this sparsely.
-///
-/// > TODO: migrate to Ell data type instead.
-pub(crate) fn ell(f: Fp12, coeffs: (Fp2, Fp2, Fp2), p: G1Affine) -> Fp12 {
-    let c0c0 = coeffs.0.c0 * p.y;
-    let c0c1 = coeffs.0.c1 * p.y;
-
-    let c1c0 = coeffs.1.c0 * p.x;
-    let c1c1 = coeffs.1.c1 * p.x;
-
-    f.mul_by_014(coeffs.2, Fp2 { c0: c1c0, c1: c1c1 }, Fp2 { c0: c0c0, c1: c0c1 })
+    (Ell::new(t9, t1_final, t10_double), G2Projective { x: new_r_x, y: new_r_y, z: new_r_z })
 }
 
 /// Evaluates the Miller loop.
@@ -116,27 +146,29 @@ pub fn miller_loop(p: G1Affine, q: G2Affine) -> Fp12 {
             found_one = i_bool;
         } else {
             // Doubling step receives f. Does 2 things: doubling_step function & ell function
-            let (coeffs_c0, coeffs_c1, coeffs_c2, cur_updated) = doubling_step(adder_cur);
+            let (ell_coeffs, cur_updated) = doubling_step(adder_cur);
+
             adder_cur = cur_updated;
-            // ell updates f
-            f = ell(f, (coeffs_c0, coeffs_c1, coeffs_c2), adder_p);
+
+            // updates f
+            f = f.sparse_mul(ell_coeffs.scale_by_affine(adder_p));
 
             if i_bool {
                 // addition_step receives f & does 2 things: addition_step & ell function
-                let (coeffs_c0, coeffs_c1, coeffs_c2, cur_updated) =
-                    addition_step(adder_cur, adder_base);
+                let (ell_coeffs, cur_updated) = addition_step(adder_cur, adder_base);
+
                 adder_cur = cur_updated;
                 // ell updates f
-                f = ell(f, (coeffs_c0, coeffs_c1, coeffs_c2), adder_p);
+                f = f.sparse_mul(ell_coeffs.scale_by_affine(adder_p));
             }
             f = f.square();
         }
     }
     // Doubling step receives f. Does 2 things: doubling_step function & ell function
-    let (coeffs_c0, coeffs_c1, coeffs_c2, cur_updated) = doubling_step(adder_cur);
+    let (ell_coeffs, cur_updated) = doubling_step(adder_cur);
     adder_cur = cur_updated;
     // ell updates f
-    f = ell(f, (coeffs_c0, coeffs_c1, coeffs_c2), adder_p);
+    f = f.sparse_mul(ell_coeffs.scale_by_affine(adder_p));
 
     f = f.conjugate();
     println(f);

--- a/lib/src/bn/fp2.nr
+++ b/lib/src/bn/fp2.nr
@@ -155,6 +155,12 @@ impl Fp2 {
         }
     }
 
+    /// Scales the element by an element of Fp.
+    pub fn scale(self, scalar: Fp) -> Self {
+        Self { c0: self.c0 * scalar, c1: self.c1 * scalar }
+    }
+
+
     /// Multiplies the element by the quadratic non-residue `u` in `Fp2`.
     ///
     /// This is used for optimized multiplication over `Fp2`.

--- a/lib/src/bn/mod.nr
+++ b/lib/src/bn/mod.nr
@@ -5,3 +5,4 @@ pub mod fp12;
 pub mod g1;
 pub mod g2;
 pub mod mod_p12m1;
+pub mod pairing;

--- a/lib/src/bn/pairing.nr
+++ b/lib/src/bn/pairing.nr
@@ -1,0 +1,49 @@
+use crate::bn::fp2::Fp2;
+use crate::bn::g1::G1Affine;
+
+/// Encapsulates sparse non-zero coefficients in Fp12.
+///
+/// There are multiple operations over elements of Fp12 where the majority of coefficients are zero,
+/// which results in unnecessary operations.
+///
+/// We define a data structure representing a more succinct form of the following.
+///
+/// ```
+/// Fp12 {
+///     c0: Fp6 {
+///        c0: Fp2 { .. },
+///        c1: Fp2::zero(),
+///        c2: Fp2::zero(),
+///     },
+///     c1: Fp6 {
+///        c0: Fp2 { .. },
+///        c1: Fp2 { .. },
+///        c2: Fp2::zero(),
+///     },
+/// }
+/// ```
+///
+/// In particular, we define this for the point doubling/addition and line evaluation algorithms.
+///
+/// Reference Document: https://eprint.iacr.org/2010/354.pdf (Algorithm 26, 27).
+pub(crate) struct Ell {
+    pub(crate) c0_c0: Fp2,
+    pub(crate) c1_c0: Fp2,
+    pub(crate) c1_c1: Fp2,
+}
+
+impl Ell {
+    /// Constructs an Ell instance with coefficients in Fp2.
+    pub(crate) fn new(c0_c0: Fp2, c1_c0: Fp2, c1_c1: Fp2) -> Self {
+        Self { c0_c0, c1_c0, c1_c1 }
+    }
+
+    /// Scales the coefficients of an Ell instance by an affine point.
+    pub(crate) fn scale_by_affine(self, p: G1Affine) -> Self {
+        Self {
+            c0_c0: self.c0_c0,
+            c1_c0: self.c1_c0.scale(p.x),
+            c1_c1: self.c1_c1.scale(p.y),
+        }
+    }
+}

--- a/lib/src/helpers.nr
+++ b/lib/src/helpers.nr
@@ -1,6 +1,6 @@
-use crate::BNfp12::Fp12;
-use crate::BNfp2::Fp2;
-use crate::BNfp6::Fp6;
+use crate::bn::fp12::Fp12;
+use crate::bn::fp2::Fp2;
+use crate::bn::fp6::Fp6;
 use crate::EXP_mod::ExpModParams;
 use crate::g1::G1Affine;
 use crate::g2::{G2Affine, G2Projective};

--- a/lib/src/helpers.nr
+++ b/lib/src/helpers.nr
@@ -1,10 +1,10 @@
 use crate::bn::fp12::Fp12;
 use crate::bn::fp2::Fp2;
 use crate::bn::fp6::Fp6;
-use crate::EXP_mod::ExpModParams;
-use crate::g1::G1Affine;
-use crate::g2::{G2Affine, G2Projective};
-use crate::mod_p12m1::ModP12M1Params;
+use crate::bn::exp_mod::ExpModParams;
+use crate::bls::g1::G1Affine;
+use crate::bls::g2::{G2Affine, G2Projective};
+use crate::bn::mod_p12m1::ModP12M1Params;
 use bignum::BigNum;
 use bignum::fields::bn254Fq::BN254_Fq_Params;
 use bignum::fns::unconstrained_ops::__pow;
@@ -18,7 +18,7 @@ pub type Fp = BigNum<3, 254, BN254_Fq_Params>;
 // the type of integers modulo p^12-1 /r
 pub type Mod_h = BigNum<24, 2790, ExpModParams>;
 // the type of integers modulo p^12 -1
-pub type Mod_p12m1 = BigNum<26, 3044, MOD_p12m1_Params>;
+pub type Mod_p12m1 = BigNum<26, 3044, ModP12M1Params>;
 
 
 /// Unconstrained final exponentiation

--- a/lib/src/lib.nr
+++ b/lib/src/lib.nr
@@ -1,3 +1,5 @@
 pub mod bn;
 pub mod bls;
 pub mod helpers;
+
+mod test;

--- a/lib/src/lib.nr
+++ b/lib/src/lib.nr
@@ -1,2 +1,3 @@
 pub mod bn;
 pub mod bls;
+pub mod helpers;

--- a/lib/src/test/pairing_test.nr
+++ b/lib/src/test/pairing_test.nr
@@ -1,9 +1,9 @@
-use crate::fp12::Fp12;
-use crate::fp2::Fp2;
-use crate::fp6::Fp6;
-use crate::g1::G1Affine;
-use crate::g2::{G2Affine, G2Projective};
-use crate::pairing::{addition_step, doubling_step, miller_loop, pairing};
+use crate::bls::fp12::Fp12;
+use crate::bls::fp2::Fp2;
+use crate::bls::fp6::Fp6;
+use crate::bls::g1::G1Affine;
+use crate::bls::g2::{G2Affine, G2Projective};
+use crate::bls::pairing::{addition_step, doubling_step, miller_loop, pairing};
 
 use dep::bignum::BigNum;
 

--- a/lib/src/test/pairing_test.nr
+++ b/lib/src/test/pairing_test.nr
@@ -7,7 +7,7 @@ use crate::bls::pairing::{addition_step, doubling_step, miller_loop, pairing};
 
 use dep::bignum::BigNum;
 
-// #[test]
+#[test]
 fn test_doubling_step() {
     let generator = G2Projective {
         x: Fp2::new(
@@ -130,20 +130,20 @@ fn test_doubling_step() {
 
     // Result are 3 Fp2's and the adjusted projective point
     // (in Rust this is changed in place, but this is not supported in Noir so it is an additional return value)
-    let res = doubling_step(generator);
+    let (ell, point) = doubling_step(generator);
 
     // Check changed point
-    assert(res.3.x.eq(doubled.x));
-    assert(res.3.y.eq(doubled.y));
-    assert(res.3.z.eq(doubled.z));
+    assert(point.x.eq(doubled.x));
+    assert(point.y.eq(doubled.y));
+    assert(point.z.eq(doubled.z));
 
     // Check Fp2's
-    assert(res.0.eq(a));
-    assert(res.1.eq(b));
-    assert(res.2.eq(c));
+    assert(ell.c1_c1.eq(a));
+    assert(ell.c1_c0.eq(b));
+    assert(ell.c0_c0.eq(c));
 }
 
-// #[test]
+#[test]
 fn test_addition_step() {
     /*
   Values from zkcrypto impl
@@ -326,17 +326,17 @@ fn test_addition_step() {
 
     // Result are 3 Fp2's and the adjusted projective point
     // (in Rust this is changed in place, but this is not supported in Noir so it is an additional return value)
-    let res: (Fp2, Fp2, Fp2, G2Projective) = addition_step(point1, affine);
+    let (ell, point) = addition_step(point1, affine);
 
     // Check changed point
-    assert(res.3.x.eq(addition_res_expected.x));
-    assert(res.3.y.eq(addition_res_expected.y));
-    assert(res.3.z.eq(addition_res_expected.z));
+    assert(point.x.eq(addition_res_expected.x));
+    assert(point.y.eq(addition_res_expected.y));
+    assert(point.z.eq(addition_res_expected.z));
 
     // Check Fp2's
-    assert(res.0.eq(a));
-    assert(res.1.eq(b));
-    assert(res.2.eq(c));
+    assert(ell.c1_c1.eq(a));
+    assert(ell.c1_c0.eq(b));
+    assert(ell.c0_c0.eq(c));
 }
 
 // #[test]


### PR DESCRIPTION
This adds an `Ell` type to encapsulate an element of `Fp12` with three non-zero coefficients for faster sparse multiplication.

There's an implementation detail traceable back up to `zkcrypto/bls12_381`, where the coefficients to the `ell` function are in reverse order. We reorder the variables in the constructor `Ell::new` and adjust the `Fp12::sparse_mul` (previously `Fp12::mul_by_014`) as such.

Also `pairing.nr` was moved into the `bls` module, as it's curve-specific.